### PR TITLE
Fix for bug 27214864

### DIFF
--- a/jaxws-ri/rt/src/main/java/com/sun/xml/ws/api/addressing/WSEndpointReference.java
+++ b/jaxws-ri/rt/src/main/java/com/sun/xml/ws/api/addressing/WSEndpointReference.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 1997-2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/jaxws-ri/rt/src/main/java/com/sun/xml/ws/api/addressing/WSEndpointReference.java
+++ b/jaxws-ri/rt/src/main/java/com/sun/xml/ws/api/addressing/WSEndpointReference.java
@@ -966,7 +966,7 @@ public final class WSEndpointReference  implements WSDLExtension {
      */
     public void addReferenceParametersToList(MessageHeaders outbound) {
         for (Header header : referenceParameters) {
-            outbound.add(header);
+            outbound.addOrReplace(header);
         }
     }
     /**


### PR DESCRIPTION
After upgrading from 12.1.1 to 12.2.1.3, the customer has issues with his
WS-A enabled web service because the soap reply contains duplicated
WSA:Action/MessageID/To headers and the client rejected it.
The SOAP request had these WS-A headers:
    
        http://facade.ws.tecs.pax/PersonIntegrationAsyncWS/alarm_v1Request/wsa:Action
        9b0608b4-cf80-47b9-bde6-38229c9cd41d/wsa:MessageID
        http://facade.ws.tecs.pax/PersonIntegrationAsyncWS/alarm_v1Request/wsa:To
        
            wsa:Addresshttp://www.w3.org/2005/08/addressing/anonymous/wsa:Address
            wsa:ReferenceParameters
                wsa:Actionhttp://facade.ws.tecs.pax/PersonIntegrationAsyncWS/alarm_v1Request/wsa:Action
                wsa:MessageIDe51373fd-0656-4f8d-949f-b8053339418e/wsa:MessageID
                wsa:Tohttp://facade.ws.tecs.pax/PersonIntegrationAsyncWS/alarm_v1Request/wsa:To 

Changed the jaxws-ri code from add to addOrReplace method to avoid duplicates