### PR TITLE
Fix for bug 26497272

### DIFF
--- a/jaxws-ri/rt/src/main/java/com/sun/xml/ws/util/pipe/AbstractSchemaValidationTube.java
+++ b/jaxws-ri/rt/src/main/java/com/sun/xml/ws/util/pipe/AbstractSchemaValidationTube.java
@@ -534,6 +534,8 @@ public abstract class AbstractSchemaValidationTube extends AbstractFilterTubeImp
         final StringBuilder sb = new StringBuilder("<xsd:schema xmlns:xsd='http://www.w3.org/2001/XMLSchema' targetNamespace='urn:x-jax-ws-master'>\n");
         for(Map.Entry<String, String> e : docs.entrySet()) {
             String systemId = e.getValue();
+            if(systemId.indexOf('&') != -1)
+                systemId = systemId.replace("&","&amp;");
             String ns = e.getKey();
             sb.append("<xsd:import schemaLocation='").append(systemId).append("'");
             if (ns != null && !("".equals(ns))) {


### PR DESCRIPTION
Modified the code so that if the schemaLocation in generated WSDL contains '&' it is replaced with '&amp;' otherwise schema validation is failing