### PR TITLE
Fix for the bug 26497272

### DIFF
--- a/jaxws-ri/rt/src/main/java/com/sun/xml/ws/util/pipe/AbstractSchemaValidationTube.java
+++ b/jaxws-ri/rt/src/main/java/com/sun/xml/ws/util/pipe/AbstractSchemaValidationTube.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 1997-2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development


### PR DESCRIPTION
Here the issue is that the JAX-WS is creating a master pseudo schema  and the & present in schemaLocation is not transformed to amp&; due to which we are getting SchemaValidationError
So I have modified the masterPseudoSchema method in AbstractSchemaValidationTube.java as follows
1. First creating a document schema and adding the elements needed for masterPseudoSchema
2. then creating DOMSource from the above created document                                                  
3. then transforming DOMSource to xml string which will expand the required characters                                                             
4. finally creating and returning StreamSource from the above transformed xml string
