### PR TITLE
update dependencies

### DIFF
--- a/jaxws-ri/boms/bom-ext/pom.xml
+++ b/jaxws-ri/boms/bom-ext/pom.xml
@@ -62,7 +62,7 @@
     <url>https://javaee.github.io/metro-jax-ws</url>
 
     <properties>
-        <ant.version>1.9.8</ant.version>
+        <ant.version>1.10.2</ant.version>
         <asm.version>3.1</asm.version>
         <commonj.sdo.version>2.1.1.v201112051852</commonj.sdo.version>
         <eclipselink.version>2.7.2</eclipselink.version>

--- a/jaxws-ri/boms/bom/pom.xml
+++ b/jaxws-ri/boms/bom/pom.xml
@@ -120,8 +120,8 @@
         <saaj-api.version>1.4.0</saaj-api.version>
         <saaj-impl.version>1.5.0</saaj-impl.version>
         <streambuffer.version>1.5.5</streambuffer.version>
-        <woodstox-core-asl.version>4.4.1</woodstox-core-asl.version>
-        <stax2-api.version>3.1.4</stax2-api.version>
+        <woodstox-core.version>5.1.0</woodstox-core.version>
+        <stax2-api.version>4.1</stax2-api.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version> <!-- 1.8 -->
         <javax.activation.version>1.2.0</javax.activation.version>
     </properties>
@@ -131,9 +131,9 @@
 
             <!-- Parsers -->
             <dependency>
-                <groupId>org.codehaus.woodstox</groupId>
-                <artifactId>woodstox-core-asl</artifactId>
-                <version>${woodstox-core-asl.version}</version>
+                <groupId>com.fasterxml.woodstox</groupId>
+                <artifactId>woodstox-core</artifactId>
+                <version>${woodstox-core.version}</version>
                 <exclusions>
                     <!-- part of JDK 6+ -->
                     <exclusion>
@@ -245,8 +245,8 @@
                 <exclusions>
                     <!-- using direct (possibly optional) dependency -->
                     <exclusion>
-                        <artifactId>woodstox-core-asl</artifactId>
-                        <groupId>org.codehaus.woodstox</groupId>
+                        <artifactId>woodstox-core</artifactId>
+                        <groupId>com.fasterxml.woodstox</groupId>
                     </exclusion>
                     <!-- part of JDK 6+ -->
                     <exclusion>

--- a/jaxws-ri/bundles/jaxws-ri-jdk/pom.xml
+++ b/jaxws-ri/bundles/jaxws-ri-jdk/pom.xml
@@ -101,8 +101,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.woodstox</groupId>
-            <artifactId>woodstox-core-asl</artifactId>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jaxws-ri/bundles/jaxws-rt/pom.xml
+++ b/jaxws-ri/bundles/jaxws-rt/pom.xml
@@ -117,8 +117,8 @@
         </dependency>
 
         <dependency>
-            <artifactId>woodstox-core-asl</artifactId>
-            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <groupId>com.fasterxml.woodstox</groupId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/jaxws-ri/jaxws-maven-plugin/pom.xml
+++ b/jaxws-ri/jaxws-maven-plugin/pom.xml
@@ -110,33 +110,18 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
-                <artifactId>maven-project</artifactId>
-                <version>3.0-alpha-2</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>maven-model</artifactId>
-                        <groupId>org.apache.maven</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>plexus-interpolation</artifactId>
-                        <groupId>org.codehaus.plexus</groupId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven</groupId>
                 <artifactId>maven-plugin-api</artifactId>
-                <version>3.2.3</version>
+                <version>3.5.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-core</artifactId>
-                <version>3.2.3</version>
+                <version>3.5.2</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-utils</artifactId>
-                <version>3.0.17</version>
+                <version>3.1.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.plugin-tools</groupId>
@@ -147,23 +132,23 @@
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>6.8.5</version>
+                <version>6.14.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-settings</artifactId>
-                <version>3.2.3</version>
+                <version>3.5.2</version>
             </dependency>
             <dependency>
-                <groupId>org.eclipse.aether</groupId>
-                <artifactId>aether-api</artifactId>
-                <version>1.0.0.v20140518</version>
+                <groupId>org.apache.maven.resolver</groupId>
+                <artifactId>maven-resolver-api</artifactId>
+                <version>1.1.1</version>
             </dependency>
             <dependency>
-                <groupId>org.eclipse.aether</groupId>
-                <artifactId>aether-util</artifactId>
-                <version>1.0.0.v20140518</version>
+                <groupId>org.apache.maven.resolver</groupId>
+                <artifactId>maven-resolver-util</artifactId>
+                <version>1.1.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -178,10 +163,6 @@
             <groupId>org.jvnet.jaxb2_commons</groupId>
             <artifactId>jaxb2-basics</artifactId>
             <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-project</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -208,12 +189,12 @@
             <artifactId>maven-settings</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-api</artifactId>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-util</artifactId>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-util</artifactId>
         </dependency>
     </dependencies>
 

--- a/jaxws-ri/pom.xml
+++ b/jaxws-ri/pom.xml
@@ -438,12 +438,12 @@
                         <dependency>
                             <groupId>org.apache.ant</groupId>
                             <artifactId>ant</artifactId>
-                            <version>1.9.5</version>
+                            <version>1.10.2</version>
                         </dependency>
                         <dependency>
                             <groupId>org.apache.ant</groupId>
                             <artifactId>ant-junit</artifactId>
-                            <version>1.9.5</version>
+                            <version>1.10.2</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/jaxws-ri/rt/pom.xml
+++ b/jaxws-ri/rt/pom.xml
@@ -100,8 +100,8 @@
             <artifactId>mimepull</artifactId>
         </dependency>
         <dependency>
-            <artifactId>woodstox-core-asl</artifactId>
-            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <groupId>com.fasterxml.woodstox</groupId>
         </dependency>
         <dependency>
             <groupId>org.codehaus.woodstox</groupId>

--- a/jaxws-ri/tests/unit/pom.xml
+++ b/jaxws-ri/tests/unit/pom.xml
@@ -345,8 +345,8 @@
 
                 <!-- Parsers -->
                 <dependency>
-                    <groupId>org.codehaus.woodstox</groupId>
-                    <artifactId>woodstox-core-asl</artifactId>
+                    <groupId>com.fasterxml.woodstox</groupId>
+                    <artifactId>woodstox-core</artifactId>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>


### PR DESCRIPTION
update 3rd-party dependencies for EE4J migration.
ant to 1.10.2
woodstox to 5.1.0
stax2-api to 4.1
maven-core/maven-plugin-api/maven-settings to 3.5.2
plexus-utils to 3.1.0
org.eclipse.aether to maven resolver 1.1.1
org.testng to 6.14.2